### PR TITLE
OPS-815 Prepare existing PGBouncer buildpack for upgrade

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,5 +66,6 @@ echo "-----> Creating symlinks app/bin/{start-pgbouncer, use-pgbouncer} -> app/b
 cd $BUILD_DIR/bin
 ln -s start-pgbouncer-stunnel start-pgbouncer
 ln -s start-pgbouncer-stunnel use-pgbouncer
+cd -
 
 echo "-----> pgbouncer/stunnel done"

--- a/bin/compile
+++ b/bin/compile
@@ -62,4 +62,9 @@ mkdir -p $BUILD_DIR/bin
 cp "$BUILDPACK_DIR/bin/start-pgbouncer-stunnel" $BUILD_DIR/bin/
 chmod +x $BUILD_DIR/bin/start-pgbouncer-stunnel
 
+echo "-----> Creating symlinks app/bin/{start-pgbouncer, use-pgbouncer} -> app/bin/start-pgbouncer-stunnel"
+cd $BUILD_DIR/bin
+ln -s start-pgbouncer-stunnel start-pgbouncer
+ln -s start-pgbouncer-stunnel use-pgbouncer
+
 echo "-----> pgbouncer/stunnel done"


### PR DESCRIPTION
This PR will make it possible to update `pulse360/Procfile` with the non-deprecated target `bin/start-pgbouncer` while still staying functional with both the old and the newer version by creating symlinks for the new references pointing back at the old:

/bin/start-pgbouncer -> /bin/start-pgbouncer-stunnel
/bin/use-pgbouncer -> /bin/start-pgbouncer-stunnel